### PR TITLE
add ssh default flag to docker compose

### DIFF
--- a/.github/workflows/byge-create-PR-go.yml
+++ b/.github/workflows/byge-create-PR-go.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build Docker image with docker-compose
         run: |
           cd ${{ inputs.docker_path }}
-          docker compose -f docker-compose.production.yml build
+          docker compose -f docker-compose.production.yml build --ssh default
 
   lint-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There was an issue reaching the `byge-common` repo with the docker compose function, working when adding the `--ssh default` flag.  By this we explicity allow ssh authentication when building the image