### PR TITLE
upgrade ci to use go 1.22

### DIFF
--- a/.github/workflows/byge-create-PR-go.yml
+++ b/.github/workflows/byge-create-PR-go.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.21.x]
+        go-version: [1.22.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Since all images use `golang:1-alpine` the running go version is now `1.22` 