### PR TITLE
upgrade linter and tests to run on go 1.23

### DIFF
--- a/.github/workflows/byge-create-PR-go.yml
+++ b/.github/workflows/byge-create-PR-go.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Simple update to the newest go version