### PR TITLE
upgrade golangci version and extend timeout duration to 3m

### DIFF
--- a/.github/workflows/byge-create-PR-go.yml
+++ b/.github/workflows/byge-create-PR-go.yml
@@ -57,12 +57,12 @@ jobs:
           # Require: The version of golangci-lint to use.
           # When `install-mode` is `binary` (default) the value can be v1.2 or v1.2.3 or `latest` to use the latest version.
           # When `install-mode` is `goinstall` the value can be v1.2.3, `latest`, or the hash of a commit.
-          version: v1.54
+          version: 1.60
 
           # Optional: working directory, useful for monorepos
           working-directory: ${{ inputs.go_module_path }}
 
-          args: --timeout 2m --verbose
+          args: --timeout 3m --verbose
 
 
   run-tests-go:


### PR DESCRIPTION
## possible fix for ci linting not completing in time with go 1.23