### PR TITLE
add govulncheck to ci lint job

### DIFF
--- a/.github/workflows/byge-create-PR-go.yml
+++ b/.github/workflows/byge-create-PR-go.yml
@@ -64,6 +64,15 @@ jobs:
 
           args: --timeout 3m --verbose
 
+      - name: Install govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: |
+          cd ${{ inputs.go_module_path }}
+          govulncheck ./...
+
 
   run-tests-go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After getting recommended the `govulncheck` (https://jarosz.dev/article/writing-secure-go-code/) to check for vulnerabilities, it is implemented in the CI flow to help us constantly check for and be on top of upcoming possible flaws in our code